### PR TITLE
Add series/serial_number metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,6 @@
 doc_id: 'SQR-001'
+series: 'SQR'
+serial_number: '001'
 doc_title: 'Git LFS Architecture Note'
 copyright: '2017, AURA/LSST'
 authors:


### PR DESCRIPTION
These fields are part of the modern spec for metadata.yaml.